### PR TITLE
Fixed compatibility issue when jQuery is loaded in footer.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -241,14 +241,18 @@ class GW_Cache_Buster {
 		}
 		?>
 		<script type="text/javascript">
-			( function ( $ ) {
-				var formId = '<?php echo $form_id; ?>';
-				$.post( '<?php echo $ajax_url; ?>', {
-					action: 'gfcb_get_form',
-					form_id: '<?php echo $form_id; ?>',
-					atts: <?php echo wp_json_encode( $atts ); ?>,
-					form_request_origin: '<?php echo esc_js( GFCommon::openssl_encrypt( GFFormsModel::get_current_page_url() ) ); ?>',
-					lang: '<?php echo $lang; ?>'
+			(function initGFCB() {
+				if (typeof jQuery === 'undefined') {
+					return setTimeout(initGFCB, 50);
+				}
+				( function ( $ ) {
+					var formId = '<?php echo $form_id; ?>';
+					$.post( '<?php echo $ajax_url; ?>', {
+						action: 'gfcb_get_form',
+						form_id: '<?php echo $form_id; ?>',
+						atts: <?php echo wp_json_encode( $atts ); ?>,
+						form_request_origin: '<?php echo esc_js( GFCommon::openssl_encrypt( GFFormsModel::get_current_page_url() ) ); ?>',
+						lang: '<?php echo $lang; ?>'
 				}, function( response ) {
 					$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
 					if( window['gformInitDatepicker'] ) {
@@ -278,6 +282,7 @@ class GW_Cache_Buster {
 					} );
 				} );
 			} )( jQuery );
+			})();
 		</script>
 
 		<?php

--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -241,10 +241,7 @@ class GW_Cache_Buster {
 		}
 		?>
 		<script type="text/javascript">
-			(function initGFCB() {
-				if (typeof jQuery === 'undefined') {
-					return setTimeout(initGFCB, 50);
-				}
+			document.addEventListener('DOMContentLoaded', function() {
 				( function ( $ ) {
 					var formId = '<?php echo $form_id; ?>';
 					$.post( '<?php echo $ajax_url; ?>', {
@@ -253,36 +250,36 @@ class GW_Cache_Buster {
 						atts: <?php echo wp_json_encode( $atts ); ?>,
 						form_request_origin: '<?php echo esc_js( GFCommon::openssl_encrypt( GFFormsModel::get_current_page_url() ) ); ?>',
 						lang: '<?php echo $lang; ?>'
-				}, function( response ) {
-					$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
-					if( window['gformInitDatepicker'] ) {
-						gformInitDatepicker();
-					}
-					// Initialize GPPA
-					// @todo Since we are not triggering the `gform_post_render` below, I'm not certain that we need this.
-					if( response.indexOf('GPPA') > -1 ) {
-						window.gform.doAction('gppa_register_form', formId);
-					}
-					// We probably don't need this since everything else should already be loaded by this point but since
-					// GF is using it as their standard for triggering the `gform_post_render` event, I figured we should follow suit.
-					gform.initializeOnLoaded( function() {
-						// Form has been rendered. Trigger post render to initialize scripts if form is not restricted (expired).
-						<?php
-							$form_restriction_error = rgars( GFFormDisplay::$submission, $form_id . '/form_restriction_error' );
-							if ( ! $form_restriction_error ) {
-								echo sprintf(
-									'gform.initializeOnLoaded(function() {%s});',
-									GFFormDisplay::post_render_script(
-										$form_id,
-										GFFormDisplay::get_current_page( $form_id )
-									)
-								);
-							}
-						?>
+					}, function( response ) {
+						$( '#gf-cache-buster-form-container-<?php echo $form_id; ?>' ).html( response ).fadeIn();
+						if( window['gformInitDatepicker'] ) {
+							gformInitDatepicker();
+						}
+						// Initialize GPPA
+						// @todo Since we are not triggering the `gform_post_render` below, I'm not certain that we need this.
+						if( response.indexOf('GPPA') > -1 ) {
+							window.gform.doAction('gppa_register_form', formId);
+						}
+						// We probably don't need this since everything else should already be loaded by this point but since
+						// GF is using it as their standard for triggering the `gform_post_render` event, I figured we should follow suit.
+						gform.initializeOnLoaded( function() {
+							// Form has been rendered. Trigger post render to initialize scripts if form is not restricted (expired).
+							<?php
+								$form_restriction_error = rgars( GFFormDisplay::$submission, $form_id . '/form_restriction_error' );
+								if ( ! $form_restriction_error ) {
+									echo sprintf(
+										'gform.initializeOnLoaded(function() {%s});',
+										GFFormDisplay::post_render_script(
+											$form_id,
+											GFFormDisplay::get_current_page( $form_id )
+										)
+									);
+								}
+							?>
+						} );
 					} );
-				} );
-			} )( jQuery );
-			})();
+				} )( jQuery );
+			});
 		</script>
 
 		<?php


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3033937651/87723?viewId=3808239

## Summary

**Issue**: The current cache buster script assumes jQuery is immediately available when the inline script executes. When jQuery is loaded in the footer, the inline script runs before jQuery loads, causing forms to show an infinite loading spinner.

**Fix:** The fix adds an `initGFCB()` wrapper function around the existing jQuery code with a `typeof jQuery === 'undefined'` check and `setTimeout` retry mechanism.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.