### PR TITLE
Fixed an issue where Gravity Forms block custom styles were not applied when cache buster was enabled.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -364,8 +364,17 @@ class GW_Cache_Buster {
 		$GLOBALS['GWCB_POST'] = $_POST;
 		$_POST                = array();
 
+		// Extract theme and styles from atts to pass to gravity_form
+		$form_theme      = rgar( $atts, 'theme' );
+		$style_settings  = rgar( $atts, 'styles' );
+
+		// JSON-encode styles if it's an array (to match expected format from blocks)
+		if ( is_array( $style_settings ) ) {
+			$style_settings = wp_json_encode( $style_settings );
+		}
+
 		$GLOBALS['processing'] = true;
-		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ) );
+		gravity_form( $form_id, filter_var( rgar( $atts, 'title', true ), FILTER_VALIDATE_BOOLEAN ), filter_var( rgar( $atts, 'description', true ), FILTER_VALIDATE_BOOLEAN ), false, $field_values, true /* default to true; add support for non-ajax in the future */, rgar( $atts, 'tabindex' ), true, $form_theme, $style_settings );
 		$GLOBALS['processing'] = false;
 
 		remove_filter( 'gform_form_tag_' . $form_id, array( $this, 'add_hidden_inputs' ) );


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3162095665/94839?viewId=3808239

## Summary

When a Gravity Forms form was embedded using the block editor and custom styling was applied through the block settings, these custom styles would not be applied to the form if the cache buster was enabled on that form using `add_filter( 'gfcb_enable_cache_buster_123', '__return_true' )`.

The issue was in the `ajax_get_form()` method, when calling the `gravity_form()` function, the method was only passing 7 parameters, leaving out the 9th parameter (`$form_theme`) and 10th parameter (`$style_settings`) that is used to apply custom block styling.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.