### PR TITLE
Fixed an issue where enabling GF Cache Buster globally caused GSPC product forms to fail rendering in WooCommerce.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -357,6 +357,21 @@ class GW_Cache_Buster {
 
 		$atts = rgpost( 'atts' );
 
+		/**
+		 * Filter to allow integrations to provide custom form markup for Cache Buster AJAX requests.
+		 * Returning a non-null string bypasses the default gravity_form() rendering.
+		 *
+		 * @param string|null     $provider_markup Custom markup. Return a string to short-circuit.
+		 * @param int             $form_id         The form ID being requested.
+		 * @param array           $atts            Shortcode attributes from the AJAX payload.
+		 * @param GW_Cache_Buster $this            The Cache Buster instance.
+		 */
+		$provider_markup = gf_apply_filters( array( 'gfcb_form_markup_provider', $form_id ), null, $form_id, $atts, $this );
+		if ( is_string( $provider_markup ) ) {
+			echo $provider_markup;
+			die();
+		}
+
 		// GF expects an associative array for field values. Parse them before passing it on.
 		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3228102267/97824?viewId=3808239

## Summary

**Issue**: When Cache Buster is globally enabled, it replaces the initial Gravity Forms markup with a loader and asynchronously fetches the form HTML. GSPC forms need the original form markup in order to build and merge the product form into WooCommerce's add-to-cart flow. Applying Cache Buster markup replacement to GSPC forms caused those forms to fail rendering correctly on product pages.

**Fix**: Added a built-in compatibility check in `gf-cache-buster.php` that detects whether the current form is attached to GSPC (via `gs_product_configurator()->has_feed( $form_id )`). If so, Cache Buster now returns the original form markup and skips placeholder replacement for that form.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.