### PR TITLE
Improved compatibility with GP Reload Form.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -18,6 +18,8 @@ class GW_Cache_Buster {
 
 	private $_form_args = array();
 
+	private $_is_form_submission = false;
+
 	public function __construct( $args = array() ) {
 
 		// set our default arguments, parse against the provided arguments, and store for use throughout the class
@@ -40,6 +42,9 @@ class GW_Cache_Buster {
 		if ( ! property_exists( 'GFCommon', 'version' ) || ! version_compare( GFCommon::$version, '1.8', '>=' ) ) {
 			return;
 		}
+
+		// Capture at init time before anything (e.g. GP Reload Form) can clear $_POST.
+		$this->_is_form_submission = isset( $_POST['gform_submit'] );
 
 		add_filter( 'gform_shortcode_form', array( $this, 'shortcode' ), 10, 3 );
 		add_filter( 'gform_get_form_filter', array( $this, 'form_filter' ), 10, 2 );
@@ -287,7 +292,9 @@ class GW_Cache_Buster {
 	}
 
 	public function is_cache_busting_applicable() {
-		if ( isset( $_POST['gform_submit'] ) ) {
+		// Check the flag captured at init time — $_POST may have been cleared by the time this runs
+		// (e.g. GP Reload Form clears $_POST before calling gravity_form() inside gform_confirmation).
+		if ( $this->_is_form_submission ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3324557608/102402?viewId=3808239

## Summary

GP Reload Form link does not work if GF Cache Buster is enabled. This is because `is_cache_busting_applicable()` relied on `isset($_POST['gform_submit'])` to detect form submissions. However, GPRF clears `$_POST` before calling `gravity_form()` inside `append_form_markup()`. As a result, by the time the cache buster check ran, `$_POST` was empty.

This PR proposes capturing the form submission state early during init using a new pre-captured `$_is_form_submission` flag. Also, `is_cache_busting_applicable` check is now replaced stored flag so submission detection remains accurate even if `$_POST` is later cleared.

**BEFORE** (Glenn):
https://www.loom.com/share/bb6d89b8f1b147c796007fb0aa4b6dd2

**AFTER**:
https://www.loom.com/share/7cc5a66bc26c422082a297939721cc7b

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.