### PR TITLE
Fixed issue where encoded field values only populated the first dynamic field.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -364,8 +364,15 @@ class GW_Cache_Buster {
 
 		$atts = rgpost( 'atts' );
 
-		// GF expects an associative array for field values. Parse them before passing it on.
-		$field_values = wp_parse_args( rgar( $atts, 'field_values' ) );
+		// GF expects an associative array for field values. Shortcode attributes can contain
+		// HTML-encoded separators (e.g. &amp;), so decode strings before parsing the query string.
+		$field_values = rgar( $atts, 'field_values' );
+
+		if ( is_string( $field_values ) ) {
+			$field_values = wp_specialchars_decode( $field_values, ENT_QUOTES );
+		}
+
+		$field_values = wp_parse_args( $field_values );
 
 		// If `$_POST` is not an empty array GF 2.5 fails to select default values for checkbox fields. See HS#26188
 		$GLOBALS['GWCB_POST'] = $_POST;


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3336460433/102984?viewId=3808239

## Summary

**Issue**: When Cache Buster loads a form, HTML-encoded ampersands in shortcode `field_values` can cause only the first dynamic population value to be parsed correctly. The remaining values are treated as malformed keys, so their matching fields are not populated.

**Fix**: Decode special characters in string-based `field_values` before calling `wp_parse_args()`.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.
