### PR TITLE
Fixed issue where the form_theme parameter was not properly sanitized.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -351,7 +351,9 @@ class GW_Cache_Buster {
 		add_filter( 'gform_pre_render_' . $form_id, array( $this, 'replace_embed_tag_for_field_default_values' ) );
 
 		add_filter( 'gform_form_theme_slug', function( $slug, $form ) {
-			return rgar( $_REQUEST, 'form_theme' ) ?: $slug;
+			$requested_theme = sanitize_key( (string) rgar( $_REQUEST, 'form_theme' ) );
+
+			return $requested_theme ?: $slug;
 		}, 10, 2 );
 
 		add_filter( 'gpmpn_default_page_' . $form_id, function( $page ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3364575155/104097?viewId=3808239

## Summary

**Issue:** The `gfcb_get_form` AJAX action read `form_theme` directly from `$_REQUEST` and returned it through the `gform_form_theme_slug` filter without sanitization. Since Gravity Forms reflects that slug into the form markup unescaped, a crafted `form_theme` parameter could inject arbitrary HTML/JavaScript.

**Fix:** The requested theme is now passed through `sanitize_key()`, which strips everything except lowercase letters, numbers, underscores, and dashes.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.