### PR TITLE
Fixed compatibility issue where Gravity Forms blocks could hang with an infinite loading spinner in the Gutenberg editor when Cache Buster was enabled globally.

### DIFF
--- a/gf-cache-buster.php
+++ b/gf-cache-buster.php
@@ -292,6 +292,13 @@ class GW_Cache_Buster {
 	}
 
 	public function is_cache_busting_applicable() {
+		// Never cache-bust in the admin or during REST requests. The block editor renders the form
+		// preview via a REST request (ServerSideRender); the injected AJAX script never executes in
+		// that context, so the form would be stuck on the loading spinner indefinitely.
+		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return false;
+		}
+
 		// Check the flag captured at init time — $_POST may have been cleared by the time this runs
 		// (e.g. GP Reload Form clears $_POST before calling gravity_form() inside gform_confirmation).
 		if ( $this->_is_form_submission ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3371757461/104406?viewId=7098280

## Summary

This PR fixes an issue where Gravity Forms blocks would remain stuck on the loading spinner in the Gutenberg editor when cache busting was enabled globally.

The cache buster was incorrectly applied to the block editor's REST-based preview, returning markup that relied on an inline script which isn't executed by the editor. As a result, the form never loaded. The fix proposed skips cache busting in admin and REST contexts, allowing forms to render normally in the Gutenberg editor while preserving cache busting on the frontend.

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.